### PR TITLE
Morphic Mesh Refinement (Mainly)

### DIFF
--- a/examples/refine_beam.py
+++ b/examples/refine_beam.py
@@ -1,0 +1,28 @@
+import morphic
+
+xe, xn = morphic.generation.generate_element_nodes(['L3', 'L3', 'L3'], [2, 2, 2], extent=[1, 1, 1])
+
+mesh = morphic.Mesh()
+
+# Add nodes.
+for node_id, value in enumerate(xn):
+    mesh.add_stdnode(node_id + 1, value, group='_default')
+
+# Add elements.
+for element_id, element in enumerate(xe):
+    mesh.add_element(element_id + 1, ['L3', 'L3','L3'], xe[element_id] + 1)
+
+# Generate the mesh.
+mesh.generate(True) 
+
+# Refine the mesh along the xi1 direction. 
+refined_mesh_x1 = morphic.refinement.mesh_refine_along_xi1(mesh, basis=['L3', 'L3', 'L3'], fac=2) 
+
+# Refine the mesh along the xi2 direction. 
+refined_mesh_x2 = morphic.refinement.mesh_refine_along_xi2(mesh, basis=['L3', 'L3', 'L3'], fac=2)
+
+# Refine the mesh along the xi3 direction. 
+refined_mesh_x3 = morphic.refinement.mesh_refine_along_xi3(mesh, basis=['L3', 'L3', 'L3'], fac=2) 
+
+# Refine along all direction at once. 
+refined_mesh = morphic.refinement.full_refinement(mesh, basis=['L3', 'L3', 'L3'], facs=[2, 2, 2])  

--- a/examples/refine_beam.py
+++ b/examples/refine_beam.py
@@ -16,13 +16,13 @@ for element_id, element in enumerate(xe):
 mesh.generate(True) 
 
 # Refine the mesh along the xi1 direction. 
-refined_mesh_x1 = morphic.refinement.mesh_refine_along_xi1(mesh, basis=['L3', 'L3', 'L3'], fac=2) 
+refined_mesh_x1, refined_x1_xn, refined_x1_xe = morphic.refinement.mesh_refine_along_xi1(mesh, basis=['L3', 'L3', 'L3'], fac=2) 
 
 # Refine the mesh along the xi2 direction. 
-refined_mesh_x2 = morphic.refinement.mesh_refine_along_xi2(mesh, basis=['L3', 'L3', 'L3'], fac=2)
+refined_mesh_x2, refined_x2_xn, refined_x2_xe = morphic.refinement.mesh_refine_along_xi2(mesh, basis=['L3', 'L3', 'L3'], fac=2)
 
 # Refine the mesh along the xi3 direction. 
-refined_mesh_x3 = morphic.refinement.mesh_refine_along_xi3(mesh, basis=['L3', 'L3', 'L3'], fac=2) 
+refined_mesh_x3, refined_x3_xn, refined_x3_xe = morphic.refinement.mesh_refine_along_xi3(mesh, basis=['L3', 'L3', 'L3'], fac=2)
 
 # Refine along all direction at once. 
-refined_mesh = morphic.refinement.full_refinement(mesh, basis=['L3', 'L3', 'L3'], facs=[2, 2, 2])  
+refined_mesh_all, refined_all_xn, refined_all_xe = morphic.refinement.full_refinement(mesh, basis=['L3', 'L3', 'L3'], fac=2)

--- a/morphic/__init__.py
+++ b/morphic/__init__.py
@@ -1,7 +1,7 @@
 from morphic.mesher import Mesh
 from morphic.data import Data
 from morphic.fitter import Fit
-from morphic.fasteval import FEMatrix
+from morphic.fasteval import FEMatrix 
 from importlib import reload
 
 reload_modules = True
@@ -13,5 +13,14 @@ if reload_modules:
     from morphic.mesher import Mesh
     from morphic import fitter
     reload(fitter)
-    from morphic.fitter import Fit
+    from morphic.fitter import Fit 
+    from morphic import data 
+    reload(data) 
+    from morphic.data import Data  
+    from morphic import fields 
+    reload(fields) 
+    from morphic import generation 
+    reload(generation) 
+    from morphic import refinement 
+    reload(refinement)
 

--- a/morphic/fields.py
+++ b/morphic/fields.py
@@ -1,0 +1,165 @@
+import numpy as np
+
+def generate_xi_on_line(line, num_points=4, dim=3, start_value=0, end_value=1):
+    """Generate linearly spaced xi values along a local element line.
+
+    Args:
+      line: Line number to generate xi values for. These are defined
+        sequentially following standard FEM numbering. E.g. for hexahedral
+        elements in 3D space, there are 1-12 lines, which are numbered by
+        considering all lines along xi1 (4 lines), followed by all lines along
+        xi2 (4 lines), followed by all lines along xi3 (4 lines).
+      num_points: Number of points generate along the xi direction.
+      dim: Dimension of the element.
+      start_value: Xi value to start generating xi values for.
+      end_value: Xi value to finish generating xi values for.
+
+    Returns:
+      xi: Linearly spaced xi values along the specified line with the specified
+        density.
+    """
+
+    if dim == 3:
+        if line == 1:
+            xi1 = np.linspace(start_value, end_value, num_points)
+            xi2 = 0
+            xi3 = 0
+        elif line == 2:
+            xi1 = np.linspace(start_value, end_value, num_points)
+            xi2 = 1
+            xi3 = 0
+        elif line == 3:
+            xi1 = np.linspace(start_value, end_value, num_points)
+            xi2 = 0
+            xi3 = 1
+        elif line == 4:
+            xi1 = np.linspace(start_value, end_value, num_points)
+            xi2 = 1
+            xi3 = 1
+
+        elif line == 5:
+            xi1 = 0
+            xi2 = np.linspace(start_value, end_value, num_points)
+            xi3 = 0
+        elif line == 6:
+            xi1 = 1
+            xi2 = np.linspace(start_value, end_value, num_points)
+            xi3 = 0
+        elif line == 7:
+            xi1 = 0
+            xi2 = np.linspace(start_value, end_value, num_points)
+            xi3 = 1
+        elif line == 8:
+            xi1 = 1
+            xi2 = np.linspace(start_value, end_value, num_points)
+            xi3 = 1
+
+        elif line == 9:
+            xi1 = 0
+            xi2 = 0
+            xi3 = np.linspace(start_value, end_value, num_points)
+        elif line == 10:
+            xi1 = 1
+            xi2 = 0
+            xi3 = np.linspace(start_value, end_value, num_points)
+        elif line == 11:
+            xi1 = 0
+            xi2 = 1
+            xi3 = np.linspace(start_value, end_value, num_points)
+        elif line == 12:
+            xi1 = 1
+            xi2 = 1
+            xi3 = np.linspace(start_value, end_value, num_points)
+
+        else:
+            raise ValueError(
+                'Local element number between 1-12 are supported for '
+                'hexahedral elements.')
+
+        X, Y, Z = np.meshgrid(xi1, xi2, xi3)
+        xi = np.array([
+            X.reshape((X.size)),
+            Y.reshape((Y.size)),
+            Z.reshape((Z.size))]).T
+
+    elif dim == 2:
+        if line == 1:
+            xi1 = np.linspace(start_value, end_value, num_points)
+            xi2 = 0
+        elif line == 2:
+            xi1 = np.linspace(start_value, end_value, num_points)
+            xi2 = 1
+
+        elif line == 3:
+            xi1 = 0
+            xi2 = np.linspace(start_value, end_value, num_points)
+        elif line == 4:
+            xi1 = 1
+            xi2 = np.linspace(start_value, end_value, num_points)
+
+        X, Y = np.meshgrid(xi1, xi2)
+        xi = np.array([
+            X.reshape((X.size)),
+            Y.reshape((Y.size))]).T
+
+    return xi
+
+
+def generate_xi_on_face(face, value, num_points=[4, 4], dim=3):
+    """
+    Generate a grid of points within each element
+
+    Keyword arguments:
+    face -- face to evaluate points on at the specified xi value
+    dim -- the number of xi directions
+    """
+    num_points = np.atleast_1d(num_points)
+    if len(num_points)==1:
+        num_points = np.array([num_points[0], num_points[0]])
+
+    if dim == 3:
+        if face == "xi1":
+            xi1 = [value]
+            xi2 = np.linspace(0., 1., num_points[0])
+            xi3 = np.linspace(0., 1., num_points[1])
+        elif face == "xi2":
+            xi1 = np.linspace(0., 1., num_points[0])
+            xi2 = [value]
+            xi3 = np.linspace(0., 1., num_points[1])
+        elif face == "xi3":
+            xi1 = np.linspace(0., 1., num_points[0])
+            xi2 = np.linspace(0., 1., num_points[1])
+            xi3 = [value]
+        X, Y, Z = np.meshgrid(xi1, xi2, xi3)
+        xi = np.array([
+            X.reshape((X.size)),
+            Y.reshape((Y.size)),
+            Z.reshape((Z.size))]).T
+    elif dim == 2:
+        xi1 = np.linspace(0., 1., num_points[0])
+        xi2 = np.linspace(0., 1., num_points[1])
+        X, Y = np.meshgrid(xi1, xi2)
+        xi = np.array([
+            X.reshape((X.size)),
+            Y.reshape((Y.size))]).T
+
+    return xi
+
+
+def generate_xi_grid_fem(num_points=[4, 4, 4], dim=3):
+    # Generate a grid of points within each element
+    xi1 = np.linspace(0., 1., num_points[0])
+    xi2 = np.linspace(0., 1., num_points[1])
+    if dim == 2:
+        X, Y = np.meshgrid(xi1, xi2)
+        XiNd = np.array([
+            X.reshape((X.size)),
+            Y.reshape((Y.size))]).T
+    else:
+        xi3 = np.linspace(0., 1., num_points[2])
+        X, Y, Z = np.meshgrid(xi1, xi2, xi3)
+        XiNd = np.array([
+            Z.reshape((Z.size)),
+            X.reshape((X.size)),
+            Y.reshape((Y.size))]).T
+    return XiNd

--- a/morphic/generation.py
+++ b/morphic/generation.py
@@ -1,0 +1,162 @@
+import numpy as np  
+import copy 
+
+def generate_element_nodes(basis, num_elem_xi, extent=[]):
+    A = 1
+    if basis == ['H3', 'H3']:
+        BASIS_NUMBER_OF_NODES = 4
+        NUMBER_OF_XIC = 2
+        NUMBER_OF_NODES_XIC = [2, 2]
+        NUMBER_OF_NODES_XIC.insert(0, 0)
+    elif basis == ['L2', 'L2']:
+        BASIS_NUMBER_OF_NODES = 9
+        NUMBER_OF_XIC = 2
+        NUMBER_OF_NODES_XIC = [3, 3]
+        NUMBER_OF_NODES_XIC.insert(0, 0)
+    elif basis == ['L3', 'L3']:
+        BASIS_NUMBER_OF_NODES = 16
+        NUMBER_OF_XIC = 2
+        NUMBER_OF_NODES_XIC = [4, 4]
+        NUMBER_OF_NODES_XIC.insert(0, 0)
+    elif basis == ['L3', 'L3', 'L3']:
+        BASIS_NUMBER_OF_NODES = 64
+        NUMBER_OF_XIC = 3
+        NUMBER_OF_NODES_XIC = [4, 4, 4]
+        NUMBER_OF_NODES_XIC.insert(0, 0)
+    elif basis == ['L5', 'L5', 'L5']:
+        BASIS_NUMBER_OF_NODES = 6 * 6 * 6
+        NUMBER_OF_XIC = 3
+        NUMBER_OF_NODES_XIC = [6, 6, 6]
+        NUMBER_OF_NODES_XIC.insert(0, 0)
+
+    NUMBER_OF_ELEMENTS_XIC = copy.deepcopy(num_elem_xi)
+    NUMBER_OF_ELEMENTS_XIC.insert(0, 0)
+    TOTAL_NUMBER_OF_NODES_XIC = [0] * (3)
+    TOTAL_NUMBER_OF_NODES_XIC.insert(0, 0)
+    TOTAL_NUMBER_OF_ELEMENTS_XIC = [0] * (3)
+    TOTAL_NUMBER_OF_ELEMENTS_XIC.insert(0, 0)
+
+    # Calculate sizes
+    TOTAL_NUMBER_OF_NODES = 1
+    TOTAL_NUMBER_OF_ELEMENTS = 1
+    for xic_idx in range(1, NUMBER_OF_XIC + A):
+        TOTAL_NUMBER_OF_NODES_XIC[xic_idx] = (NUMBER_OF_NODES_XIC[
+                                                  xic_idx] - 2) * \
+                                             NUMBER_OF_ELEMENTS_XIC[xic_idx] + \
+                                             NUMBER_OF_ELEMENTS_XIC[
+                                                 xic_idx] + 1
+        TOTAL_NUMBER_OF_ELEMENTS_XIC[xic_idx] = NUMBER_OF_ELEMENTS_XIC[xic_idx]
+        TOTAL_NUMBER_OF_NODES = TOTAL_NUMBER_OF_NODES * \
+                                TOTAL_NUMBER_OF_NODES_XIC[xic_idx]
+        TOTAL_NUMBER_OF_ELEMENTS = TOTAL_NUMBER_OF_ELEMENTS * \
+                                   TOTAL_NUMBER_OF_ELEMENTS_XIC[xic_idx]
+
+    Xe_nodes = np.zeros((TOTAL_NUMBER_OF_ELEMENTS, BASIS_NUMBER_OF_NODES),
+                           dtype='uint32')
+    Xeid = 0
+    # !Set the elements for the regular mesh
+    ELEMENT_NODES = [0] * (BASIS_NUMBER_OF_NODES + A)
+    # Step in the xi[3)direction
+    for ne3 in range(A, TOTAL_NUMBER_OF_ELEMENTS_XIC[3] + 1 + A):
+        for ne2 in range(A, TOTAL_NUMBER_OF_ELEMENTS_XIC[2] + 1 + A):
+            for ne1 in range(A, TOTAL_NUMBER_OF_ELEMENTS_XIC[1] + 1 + A):
+                if ((NUMBER_OF_XIC < 3) or (
+                        ne3 <= TOTAL_NUMBER_OF_ELEMENTS_XIC[3])):
+                    if (NUMBER_OF_XIC < 2 or ne2 <=
+                            TOTAL_NUMBER_OF_ELEMENTS_XIC[2]):
+                        if (ne1 <= TOTAL_NUMBER_OF_ELEMENTS_XIC[1]):
+                            ne = ne1
+                            npp = 1 + (ne1 - 1) * (NUMBER_OF_NODES_XIC[1] - 1)
+                            if (NUMBER_OF_XIC > 1):
+                                ne = ne + (ne2 - 1) * \
+                                     TOTAL_NUMBER_OF_ELEMENTS_XIC[1]
+                                npp = npp + (ne2 - 1) * \
+                                     TOTAL_NUMBER_OF_NODES_XIC[1] * (
+                                                 NUMBER_OF_NODES_XIC[2] - 1)
+                                if (NUMBER_OF_XIC > 2):
+                                    ne = ne + (ne3 - 1) * \
+                                         TOTAL_NUMBER_OF_ELEMENTS_XIC[1] * \
+                                         TOTAL_NUMBER_OF_ELEMENTS_XIC[2]
+                                    npp = npp + (ne3 - 1) * \
+                                         TOTAL_NUMBER_OF_NODES_XIC[1] * \
+                                         TOTAL_NUMBER_OF_NODES_XIC[2] * (
+                                                     NUMBER_OF_NODES_XIC[
+                                                         3] - 1)
+                            nn = 0
+                            for nn1 in range(A, NUMBER_OF_NODES_XIC[1] + A):
+                                nn = nn + 1
+                                ELEMENT_NODES[nn] = npp + (nn1 - 1)
+                            if (NUMBER_OF_XIC > 1):
+                                for nn2 in range(A + 1,
+                                                 NUMBER_OF_NODES_XIC[2] + A):
+                                    for nn1 in range(A, NUMBER_OF_NODES_XIC[
+                                                            1] + A):
+                                        nn = nn + 1
+                                        ELEMENT_NODES[nn] = npp + (nn1 - 1) + (
+                                                    nn2 - 1) * \
+                                                            TOTAL_NUMBER_OF_NODES_XIC[
+                                                                1]
+                                if (NUMBER_OF_XIC > 2):
+                                    for nn3 in range(A + 1,
+                                                     NUMBER_OF_NODES_XIC[
+                                                         3] + A):
+                                        for nn2 in range(A,
+                                                         NUMBER_OF_NODES_XIC[
+                                                             2] + A):
+                                            for nn1 in range(A,
+                                                             NUMBER_OF_NODES_XIC[
+                                                                 1] + A):
+                                                nn = nn + 1
+                                                ELEMENT_NODES[nn] = npp + (
+                                                            nn1 - 1) + (
+                                                                                nn2 - 1) * \
+                                                                    TOTAL_NUMBER_OF_NODES_XIC[
+                                                                        1] + (
+                                                                                nn3 - 1) * \
+                                                                    TOTAL_NUMBER_OF_NODES_XIC[
+                                                                        1] * \
+                                                                    TOTAL_NUMBER_OF_NODES_XIC[
+                                                                        2]
+                            # print(ELEMENT_NODES[1:len(ELEMENT_NODES)])
+                            Xe_nodes[Xeid, :] = ELEMENT_NODES[
+                                                1:len(ELEMENT_NODES)]
+                            Xeid += 1
+
+    if extent == []:
+        return Xe_nodes - 1  # Generated node numbers begin from 0
+    else:
+        Xn = np.zeros((TOTAL_NUMBER_OF_NODES, NUMBER_OF_XIC))
+
+        FIELD_NODE_USER_NUMBER = 0
+
+        if NUMBER_OF_XIC == 3:
+            VALUE = [0.0] * (3)
+            for Z_COUNTER in range(TOTAL_NUMBER_OF_NODES_XIC[3]):
+                for Y_COUNTER in range(TOTAL_NUMBER_OF_NODES_XIC[2]):
+                    for X_COUNTER in range(TOTAL_NUMBER_OF_NODES_XIC[1]):
+                        for XIC_COORDINATE in range(NUMBER_OF_XIC):
+                            Xn[FIELD_NODE_USER_NUMBER, XIC_COORDINATE] = float(
+                                VALUE[XIC_COORDINATE])
+                        FIELD_NODE_USER_NUMBER += 1
+                        VALUE[0] = float(VALUE[0]) + float(extent[0]) / float(
+                            (TOTAL_NUMBER_OF_NODES_XIC[1] - 1))
+                    VALUE[1] = float(VALUE[1]) + float(extent[1]) / float(
+                        (TOTAL_NUMBER_OF_NODES_XIC[2] - 1))
+                    VALUE[0] = 0.0
+                VALUE[2] = float(VALUE[2]) + float(extent[2]) / float(
+                    (TOTAL_NUMBER_OF_NODES_XIC[3] - 1))
+                VALUE[1] = 0.0
+        elif NUMBER_OF_XIC == 2:
+            VALUE = [0] * (2)
+            for Y_COUNTER in range(TOTAL_NUMBER_OF_NODES_XIC[2]):
+                for X_COUNTER in range(TOTAL_NUMBER_OF_NODES_XIC[1]):
+                    for XIC_COORDINATE in range(NUMBER_OF_XIC):
+                        Xn[FIELD_NODE_USER_NUMBER, XIC_COORDINATE] = VALUE[
+                            XIC_COORDINATE]
+                    FIELD_NODE_USER_NUMBER += 1
+                    VALUE[0] = VALUE[0] + (
+                                extent[0] / (TOTAL_NUMBER_OF_NODES_XIC[1] - 1))
+                VALUE[1] = extent[1] / (TOTAL_NUMBER_OF_NODES_XIC[2] - 1)
+                VALUE[0] = 0
+
+        return Xe_nodes - 1, Xn  # Generated node numbers begin from 0 

--- a/morphic/refinement.py
+++ b/morphic/refinement.py
@@ -1,0 +1,317 @@
+import numpy as np
+from morphic.mesher import Mesh
+
+def get_num_elem_nodes(basis):
+    """
+    Returns the number of element nodes based on the given basis.
+
+    Parameters:
+    basis (list): A list of basis functions.
+
+    Returns:
+    list: A list of integers representing the number of element nodes for each dimension.
+
+    Raises:
+    ValueError: If the basis is not supported.
+
+    """
+    if basis == ['L1', 'L1', 'L1']:
+        num_elem_nodes = [2, 2, 2]
+    elif basis == ['L2', 'L2', 'L2']:
+        num_elem_nodes = [3, 3, 3]
+    elif basis ==  ['L3', 'L3', 'L3']:
+        num_elem_nodes = [4, 4, 4] 
+    else:  
+        raise ValueError('Only 3D Lagrange elements up to the 3rd order (Cubic) are supported.')
+
+    return num_elem_nodes
+
+import numpy as np
+
+def generate_xi_grid(num_points=[4, 4, 4], dim=3):
+    """
+    Generate a grid of points within each element.
+
+    Parameters:
+    - num_points (list): A list of integers representing the number of points in each dimension of the grid. Default is cubic lagrange, i.e. [4, 4, 4].
+    - dim (int): The dimension of the grid. Default is 3.
+
+    Returns:
+    - XiNd (ndarray): An array of shape (N, dim), where N is the total number of points in the grid and dim is the dimension of the grid.
+    """
+
+    xi1 = np.linspace(0., 1., num_points[0])
+    xi2 = np.linspace(0., 1., num_points[1])
+
+    if dim == 2:
+        X, Y = np.meshgrid(xi1, xi2)
+        XiNd = np.array([
+            X.reshape((X.size)),
+            Y.reshape((Y.size))]).T
+    else:
+        xi3 = np.linspace(0., 1., num_points[2])
+        X, Y, Z = np.meshgrid(xi1, xi2, xi3)
+        XiNd = np.array([
+            Z.reshape((Z.size)),
+            X.reshape((X.size)),
+            Y.reshape((Y.size))]).T
+
+    return XiNd
+
+def create_morphic_mesh(basis, xn, xe): 
+    """
+    Create a morphic mesh using the given basis, node values, and element values.
+
+    Parameters:
+    - basis (str): The basis for the mesh.
+    - xn (list): The node values.
+    - xe (list): The element values.
+
+    Returns:
+    - mesh (Mesh): The generated morphic mesh.
+    """
+
+    mesh = Mesh()
+
+    for node_id, value in enumerate(xn):
+        mesh.add_stdnode(node_id + 1, value, group='_default')
+
+    for element_id, element in enumerate(xe):
+        mesh.add_element(element_id + 1, basis, xe[element_id] + 1)
+
+    mesh.generate(True)
+
+    return mesh
+
+def mesh_refine_along_xi1(mesh, basis=["L3", "L3", "L3"], fac=2): 
+    """
+    Refines a mesh along the xi1 direction.
+
+    Args:
+        mesh (MorphicMesh): The input mesh to be refined.
+        basis (list, optional): The basis functions to be used for refinement. Defaults to ["L3", "L3", "L3"].
+        fac (int, optional): The refinement factor. Defaults to 2.
+
+    Returns:
+        MorphicMesh: The refined mesh.
+
+    Raises:
+        None
+
+    Examples:
+        # Create a mesh 
+        xn, xe = generate_element_nodes(["L3", "L3", "L3"], [2, 2, 2], extent=[1, 1, 1])
+        mesh = create_morphic_mesh(["L3", "L3", "L3"], xn, xe)
+
+        # Refine the mesh along the xi1 direction
+        refined_mesh = mesh_refine_along_xi1(mesh, basis=["L3", "L3", "L3"], fac=2)
+    """
+    
+    num_elem_nodes = get_num_elem_nodes(basis)
+    xi_grid = generate_xi_grid(num_elem_nodes, dim=3)
+    elem_partitions = [(n / fac, (n + 1) / fac) for n in range(fac)]
+
+    xi_partitions = [np.array([xi_grid[:, 0] * (b[1] - b[0]) + b[0],
+                               xi_grid[:, 1],
+                               xi_grid[:, 2]]).T for b in elem_partitions]
+
+    mapping = {}
+    refined_xe = []
+    for elem_idx, elem in enumerate(mesh.elements):
+        for xi_part in xi_partitions:
+            new_elem_nodes = elem.evaluate(xi_part)
+            elem_node_ids = []
+            for node in new_elem_nodes:
+                if tuple(node) not in mapping:
+                    mapping[tuple(node)] = len(mapping)
+                elem_node_ids.append(mapping[tuple(node)])
+            refined_xe.append(elem_node_ids)
+
+    refined_xn_list = [list(point) for point in mapping.keys()]
+    refined_xn = np.array(refined_xn_list)
+
+    refined_mesh = create_morphic_mesh(basis, refined_xn, np.array(refined_xe))
+
+    return refined_mesh
+
+
+def mesh_refine_along_xi2(mesh, basis=["L3", "L3", "L3"], fac=2): 
+    """
+    Refines a mesh along the xi2 direction.
+
+    Args:
+        mesh (MorphicMesh): The input mesh to be refined.
+        basis (list, optional): The basis functions to be used for refinement. Defaults to ["L3", "L3", "L3"].
+        fac (int, optional): The refinement factor. Defaults to 2.
+
+    Returns:
+        MorphicMesh: The refined mesh.
+
+    Raises:
+        None
+
+    Examples:
+        # Create a mesh 
+        xn, xe = generate_element_nodes(["L3", "L3", "L3"], [2, 2, 2], extent=[1, 1, 1])
+        mesh = create_morphic_mesh(["L3", "L3", "L3"], xn, xe)
+
+        # Refine the mesh along the xi1 direction
+        refined_mesh = mesh_refine_along_xi1(mesh, basis=["L3", "L3", "L3"], fac=2)
+    """
+
+    num_elem_nodes = get_num_elem_nodes(basis)
+    xi_grid = generate_xi_grid(num_elem_nodes, dim=3)
+
+    elem_partitions = [(n / fac, (n + 1) / fac) for n in range(fac)]
+
+    xi_partitions = [np.array([xi_grid[:, 0],
+                               xi_grid[:, 1] * (b[1] - b[0]) + b[0],
+                               xi_grid[:, 2]]).T for b in elem_partitions]
+
+    mapping = {}
+    refined_xe = []
+    for elem_idx, elem in enumerate(mesh.elements):
+        for xi_part in xi_partitions:
+            new_elem_nodes = elem.evaluate(xi_part)
+            elem_node_ids = []
+            for node in new_elem_nodes:
+                if tuple(node) not in mapping:
+                    mapping[tuple(node)] = len(mapping)
+                elem_node_ids.append(mapping[tuple(node)])
+            refined_xe.append(elem_node_ids)
+
+    refined_xn_list = [list(point) for point in mapping.keys()]
+    refined_xn = np.array(refined_xn_list)
+
+    refined_mesh = create_morphic_mesh(basis, refined_xn, np.array(refined_xe))
+
+    return refined_mesh
+
+def mesh_refine_along_xi3(mesh, basis=["L3", "L3", "L3"], fac=2):
+    """
+    Refines a mesh along the xi3 direction.
+
+    Args:
+        mesh (MorphicMesh): The input mesh to be refined.
+        basis (list, optional): The basis functions to be used for refinement. Defaults to ["L3", "L3", "L3"].
+        fac (int, optional): The refinement factor. Defaults to 2.
+
+    Returns:
+        MorphicMesh: The refined mesh.
+
+    Raises:
+        None
+
+    Examples:
+        # Create a mesh 
+        xn, xe = generate_element_nodes(["L3", "L3", "L3"], [2, 2, 2], extent=[1, 1, 1])
+        mesh = create_morphic_mesh(["L3", "L3", "L3"], xn, xe)
+
+        # Refine the mesh along the xi1 direction
+        refined_mesh = mesh_refine_along_xi1(mesh, basis=["L3", "L3", "L3"], fac=2)
+    """
+    num_elem_nodes = get_num_elem_nodes(basis)
+    xi_grid = generate_xi_grid(num_elem_nodes, dim=3)
+    elem_partitions = [(n / fac, (n + 1) / fac) for n in range(fac)]  # e.g. for fac=2, [(0, 0.5), (0.5, 1)]
+
+    xi_partitions = [np.array([xi_grid[:, 0],
+                               xi_grid[:, 1],
+                               xi_grid[:, 2] * (b[1] - b[0]) + b[0]]).T for b in elem_partitions]
+
+    mapping = {}
+    refined_xe = []
+    for elem_idx, elem in enumerate(mesh.elements):
+        for xi_part in xi_partitions:
+            new_elem_nodes = elem.evaluate(xi_part)
+            elem_node_ids = []
+            for node in new_elem_nodes:
+                # Check if point is already in the mapping, if not add it
+                if tuple(node) not in mapping:
+                    mapping[tuple(node)] = len(mapping)
+                elem_node_ids.append(mapping[tuple(node)])
+            refined_xe.append(elem_node_ids)
+
+    # Generate the list of refined mesh nodes based on the mapping
+    refined_xn_list = [list(point) for point in mapping.keys()]
+    refined_xn = np.array(refined_xn_list)
+
+    # Update the refined mesh with the new nodes
+    refined_mesh = create_morphic_mesh(basis, refined_xn, np.array(refined_xe))
+
+    return refined_mesh
+
+
+def full_refinement(mesh, basis=["L3", "L3", "L3"], facs=[2, 2, 2]):
+    """
+    Perform full refinement of a mesh.
+
+    Args:
+        mesh (MorphicMesh): The input mesh to be refined.
+        basis (list, optional): The basis functions to be used for refinement. Defaults to ["L3", "L3", "L3"].
+        facs (list, optional): The refinement factors for each xi direction. Defaults to [2, 2, 2].
+
+    Returns:
+        MorphicMesh: The refined mesh. 
+
+    Examples:
+        # Create a mesh 
+        xn, xe = morphic.generation.generate_element_nodes(["L3", "L3", "L3"], [2, 2, 2], extent=[1, 1, 1])
+        mesh = morphic.Mesh()
+
+        # Add nodes.
+        for node_id, value in enumerate(xn):
+            mesh.add_stdnode(node_id + 1, value, group='_default')
+
+        # Add elements.
+        for element_id, element in enumerate(xe):
+            mesh.add_element(element_id + 1, ['L3', 'L3','L3'], xe[element_id] + 1)
+
+        # Generate the mesh.
+        mesh.generate(True) 
+
+        # Refine the mesh along the xi1 direction
+        refined_mesh = morphic.refinement.full_refinement(mesh, basis=["L3", "L3", "L3"], fac=2)
+
+    """
+    
+    num_elem_nodes = get_num_elem_nodes(basis)
+    xi_grid = generate_xi_grid(num_elem_nodes, dim=3)
+
+    # Generate element partitions for each xi direction
+    elem_partitions_xi1 = [(n / facs[0], (n + 1) / facs[0]) for n in range(facs[0])]
+    elem_partitions_xi2 = [(n / facs[1], (n + 1) / facs[1]) for n in range(facs[1])]
+    elem_partitions_xi3 = [(n / facs[2], (n + 1) / facs[2]) for n in range(facs[2])]
+
+    # Combine the partitions for all xi directions
+    xi_partitions = []
+    for xi1_part in elem_partitions_xi1:
+        for xi2_part in elem_partitions_xi2:
+            for xi3_part in elem_partitions_xi3:
+                xi_partitions.append(np.array([xi_grid[:, 0] * (xi1_part[1] - xi1_part[0]) + xi1_part[0],
+                                               xi_grid[:, 1] * (xi2_part[1] - xi2_part[0]) + xi2_part[0],
+                                               xi_grid[:, 2] * (xi3_part[1] - xi3_part[0]) + xi3_part[0]]).T)
+
+    # Initialize mapping and refined element list
+    mapping = {}
+    refined_xe = []
+
+    # Iterate over elements and xi partitions to refine the mesh
+    for elem_idx, elem in enumerate(mesh.elements):
+        for xi_part in xi_partitions:
+            new_elem_nodes = elem.evaluate(xi_part)
+            elem_node_ids = []
+            for node in new_elem_nodes:
+                # Check if point is already in the mapping, if not add it
+                if tuple(node) not in mapping:
+                    mapping[tuple(node)] = len(mapping)
+                elem_node_ids.append(mapping[tuple(node)])
+            refined_xe.append(elem_node_ids)
+
+    # Generate the list of refined mesh nodes based on the mapping
+    refined_xn_list = [list(point) for point in mapping.keys()]
+    refined_xn = np.array(refined_xn_list)
+
+    # Update the refined mesh with the new nodes
+    refined_mesh = create_morphic_mesh(basis, refined_xn, np.array(refined_xe))
+
+    return refined_mesh

--- a/morphic/refinement.py
+++ b/morphic/refinement.py
@@ -128,11 +128,12 @@ def mesh_refine_along_xi1(mesh, basis=["L3", "L3", "L3"], fac=2):
             refined_xe.append(elem_node_ids)
 
     refined_xn_list = [list(point) for point in mapping.keys()]
-    refined_xn = np.array(refined_xn_list)
+    refined_xn = np.array(refined_xn_list) 
+    refined_xe = np.array(refined_xe)
 
-    refined_mesh = create_morphic_mesh(basis, refined_xn, np.array(refined_xe))
+    refined_mesh = create_morphic_mesh(basis, refined_xn, refined_xe)
 
-    return refined_mesh
+    return refined_mesh, refined_xn, refined_xe
 
 
 def mesh_refine_along_xi2(mesh, basis=["L3", "L3", "L3"], fac=2): 
@@ -181,11 +182,12 @@ def mesh_refine_along_xi2(mesh, basis=["L3", "L3", "L3"], fac=2):
             refined_xe.append(elem_node_ids)
 
     refined_xn_list = [list(point) for point in mapping.keys()]
-    refined_xn = np.array(refined_xn_list)
+    refined_xn = np.array(refined_xn_list) 
+    refined_xe = np.array(refined_xe) 
 
-    refined_mesh = create_morphic_mesh(basis, refined_xn, np.array(refined_xe))
+    refined_mesh = create_morphic_mesh(basis, refined_xn, refined_xe)
 
-    return refined_mesh
+    return refined_mesh, refined_xn, refined_xe
 
 def mesh_refine_along_xi3(mesh, basis=["L3", "L3", "L3"], fac=2):
     """
@@ -233,12 +235,14 @@ def mesh_refine_along_xi3(mesh, basis=["L3", "L3", "L3"], fac=2):
 
     # Generate the list of refined mesh nodes based on the mapping
     refined_xn_list = [list(point) for point in mapping.keys()]
-    refined_xn = np.array(refined_xn_list)
+    refined_xn = np.array(refined_xn_list) 
+    refined_xe = np.array(refined_xe)
 
-    # Update the refined mesh with the new nodes
-    refined_mesh = create_morphic_mesh(basis, refined_xn, np.array(refined_xe))
+    # Update the refined mesh with the new nodes 
+    refined_mesh = create_morphic_mesh(basis, refined_xn, refined_xe)
+    
 
-    return refined_mesh
+    return refined_mesh, refined_xn, refined_xe
 
 
 def full_refinement(mesh, basis=["L3", "L3", "L3"], facs=[2, 2, 2]):
@@ -309,9 +313,10 @@ def full_refinement(mesh, basis=["L3", "L3", "L3"], facs=[2, 2, 2]):
 
     # Generate the list of refined mesh nodes based on the mapping
     refined_xn_list = [list(point) for point in mapping.keys()]
-    refined_xn = np.array(refined_xn_list)
+    refined_xn = np.array(refined_xn_list) 
+    refined_xe = np.array(refined_xe)
 
     # Update the refined mesh with the new nodes
-    refined_mesh = create_morphic_mesh(basis, refined_xn, np.array(refined_xe))
+    refined_mesh = create_morphic_mesh(basis, refined_xn, refined_xe)
 
-    return refined_mesh
+    return refined_mesh, refined_xn, refined_xe

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+meshio==4.3.5
+h5py 
+scipy

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+# Note: To use the 'upload' functionality of this file, you must:
+#   $ pipenv install twine --dev
+
+import io
+import os
+import sys
+from shutil import rmtree
+
+from setuptools import find_packages, setup, Command
+
+# Package meta-data.
+NAME = 'morphic'
+DESCRIPTION = 'A Fundamental Package for Working with Finite Element Meshes in Python.'
+URL = 'https://github.com/PrasadBabarendaGamage/morphic'
+EMAIL = 'tp.babarendagamage@auckland.ac.nz'
+AUTHOR = 'Duane Malcolm, Prasad Babarenda Gamage and others.'
+REQUIRES_PYTHON = '>=3.8.0'
+VERSION = '0.1.0'
+
+# What packages are required for this module to be executed?
+REQUIRED = ['meshio==4.3.5', 'h5py', 'scipy'
+    # 'requests', 'maya', 'records',
+]
+
+# What packages are optional?
+EXTRAS = {
+    # 'fancy feature': ['django'],
+}
+
+# The rest you shouldn't have to touch too much :)
+# ------------------------------------------------
+# Except, perhaps the License and Trove Classifiers!
+# If you do change the License, remember to change the Trove Classifier for that!
+
+here = os.path.abspath(os.path.dirname(__file__))
+
+# Import the README and use it as the long-description.
+# Note: this will only work if 'README.md' is present in your MANIFEST.in file!
+try:
+    with io.open(os.path.join(here, 'README.md'), encoding='utf-8') as f:
+        long_description = '\n' + f.read()
+except FileNotFoundError:
+    long_description = DESCRIPTION
+
+# Load the package's __version__.py module as a dictionary.
+about = {}
+if not VERSION:
+    project_slug = NAME.lower().replace("-", "_").replace(" ", "_")
+    with open(os.path.join(here, project_slug, '__version__.py')) as f:
+        exec(f.read(), about)
+else:
+    about['__version__'] = VERSION
+
+
+class UploadCommand(Command):
+    """Support setup.py upload."""
+
+    description = 'Build and publish the package.'
+    user_options = []
+
+    @staticmethod
+    def status(s):
+        """Prints things in bold."""
+        print('\033[1m{0}\033[0m'.format(s))
+
+    def initialize_options(self):
+        pass
+
+    def finalize_options(self):
+        pass
+
+    def run(self):
+        try:
+            self.status('Removing previous builds…')
+            rmtree(os.path.join(here, 'dist'))
+        except OSError:
+            pass
+
+        self.status('Building Source and Wheel (universal) distribution…')
+        os.system('{0} setup.py sdist bdist_wheel --universal'.format(sys.executable))
+
+        self.status('Uploading the package to PyPI via Twine…')
+        os.system('twine upload dist/*')
+
+        self.status('Pushing git tags…')
+        os.system('git tag v{0}'.format(about['__version__']))
+        os.system('git push --tags')
+
+        sys.exit()
+
+
+# Where the magic happens:
+setup(
+    name=NAME,
+    version=about['__version__'],
+    description=DESCRIPTION,
+    long_description=long_description,
+    long_description_content_type='text/markdown',
+    author=AUTHOR,
+    author_email=EMAIL,
+    python_requires=REQUIRES_PYTHON,
+    url=URL,
+    packages=find_packages(exclude=["tests", "*.tests", "*.tests.*", "tests.*"]),
+    # If your package is a single module, use this instead of 'packages':
+    # py_modules=['morphic'],
+
+    # entry_points={
+    #     'console_scripts': ['mycli=mymodule:cli'],
+    # },
+    install_requires=REQUIRED,
+    extras_require=EXTRAS,
+    include_package_data=True,
+    license='MIT',
+    classifiers=[
+        # Trove classifiers
+        # Full list: https://pypi.python.org/pypi?%3Aaction=list_classifiers
+        'License :: OSI Approved :: GLP-2.0 License',
+        'Programming Language :: Python',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: Implementation :: CPython',
+        'Programming Language :: Python :: Implementation :: PyPy'
+    ],
+    # $ setup.py publish support.
+    cmdclass={
+        'upload': UploadCommand,
+    },
+)


### PR DESCRIPTION
This PR includes:

1. Added h-refinement method for Morphic mesh in `morphic/refinement`, allowing increased elements (h-refinement) rather than polynomial order (p-refinement). An example demonstrates beam refinement along each xi direction (e.g. `mesh_refine_along_xi1`) or multiple xi directions simultaneously (i.e. `full_refinement`). Refinement functions for individual xi directions may be deprecated later but are kept for clarity (refinement of individual xi can be done with `full_refinement`).

2. Moved certain functions from mesh-tools to morphic for organization. Functions like `generate_xi_grid_fem`, `generate_xi_on_line`, and `generate_element_nodes` are included for convenience.

3. Added `setup.py` for easy pip install of Morphic. Updated `requirements.txt` for dependencies.